### PR TITLE
Clarify code guidelines and remove diagram references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,24 +6,18 @@ This document provides guidance for AI agents working in this repository.
 - Do not modify `AGENTS.md` unless explicitly requested.
 - Use `rg` for searching; avoid commands like `grep -R` or `ls -R`.
 - After modifying files, run all available tests with `pytest`. If other test suites are introduced, run them as well.
+- When modifying the Helm chart, run `helm lint charts/llm-gateway` and ensure it succeeds. If linting fails, identify and fix the issue, then rerun the command until it passes.
+- For Helm chart development, define default values for variables in the `values.yaml` file unless explicitly requested otherwise or when implementation constraints make it technically infeasible.
+- When modifying Helm charts, update `values.schema.json` to cover every variable used. Ensure the schema is complete, syntactically valid, and includes both validation rules and metadata documenting each value's behavior and effects.
+- Unless explicitly instructed otherwise, adhere to Helm.sh and Kubernetes best practices when developing or modifying charts.
 - Keep commits focused and descriptive, using the present tense (e.g., "Add feature" rather than "Added feature").
 
 ## Code style
 - Maintain consistent formatting with any tools configured in the repository. If formatting tools (such as `black` or `pre-commit`) are available, run them before committing.
+- Write code—including Helm templates and configuration—with a clear and readable style so that even less-experienced contributors can understand it.
+- Take inspiration from the style used in Bitnami charts, but avoid introducing dependencies on external charts unless explicitly requested.
 ## Documentation
 - Use English for all documentation, comments, and notes.
+- Comment critical sections of code to explain their purpose and rationale; where helpful, note other areas of the code that a change may impact.
 - Update documentation or comments when behavior changes or new features are introduced.
 - Prefer Markdown as the format for documentation artifacts.
-- Create diagrams as code using Mermaid embedded in Markdown files.
-- Validate Mermaid diagrams with `mmdc` (Mermaid CLI) to ensure syntax is correct and diagrams render successfully.
-  - Install Mermaid CLI if it is not already available:
-    ```bash
-    npm install -g @mermaid-js/mermaid-cli
-    ```
-  - Render a diagram to check for syntax errors:
-    ```bash
-    mmdc -i diagram.mmd -o /tmp/diagram.svg
-    ```
-    The command fails when the diagram contains invalid syntax.
-- Use the C4 model for architecture diagrams.
-- Use sequence diagrams for component interactions.


### PR DESCRIPTION
## Summary
- Document Helm chart validation requirement in AGENTS.md
- Recommend keeping Helm variable defaults in `values.yaml`
- Encourage clear, readable code and thorough commenting of critical sections
- Require `values.schema.json` to stay updated with chart variables and include validating metadata
- Advise following Bitnami chart style without external dependencies
- Drop Mermaid and C4 diagram references to focus on Helm charts
- Instruct adopting Helm.sh and Kubernetes best practices unless explicitly told otherwise

## Testing
- `helm lint charts/llm-gateway`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6895f8fc3f5483328f3f2d75e8bf9862