### PR TITLE
Add PodDisruptionBudget to llm-gateway chart

### DIFF
--- a/charts/llm-gateway/Chart.yaml
+++ b/charts/llm-gateway/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/llm-gateway/templates/pdb.yaml
+++ b/charts/llm-gateway/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.pdb.enabled }}
+{{- $defaultMinAvailable := max (sub (int .Values.replicaCount) 1) 0 -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "llm-gateway.fullname" . }}
+  namespace: {{ include "llm-gateway.namespace" . }}
+  labels:
+    {{- include "llm-gateway.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable | default $defaultMinAvailable }}
+  selector:
+    matchLabels:
+      {{- include "llm-gateway.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/llm-gateway/values.schema.json
+++ b/charts/llm-gateway/values.schema.json
@@ -99,6 +99,23 @@
         }
       },
       "required": ["type", "port"]
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Create a PodDisruptionBudget for the deployment."
+        },
+        "minAvailable": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "default": null,
+          "description": "Minimum number of pods that must remain available. Defaults to replicaCount - 1 with a minimum of 0."
+        }
+      },
+      "required": ["enabled"]
     }
   },
   "required": [

--- a/charts/llm-gateway/values.yaml
+++ b/charts/llm-gateway/values.yaml
@@ -13,3 +13,8 @@ image:
 service:
   type: ClusterIP
   port: 80
+
+pdb:
+  enabled: true
+  # By default, minAvailable is computed as replicaCount - 1 with a minimum of 0
+  minAvailable: null


### PR DESCRIPTION
## Summary
- add PodDisruptionBudget linked to the deployment
- configure default minAvailable to replicaCount-1 with a minimum of 0
- expose pdb settings in values and schema and bump chart version

## Testing
- `helm lint charts/llm-gateway`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68961e9d04b88332914bea1ece09c50f