### PR TITLE
Allow replicaCount to be zero

### DIFF
--- a/charts/llm-gateway/values.schema.json
+++ b/charts/llm-gateway/values.schema.json
@@ -9,9 +9,9 @@
     },
     "replicaCount": {
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "default": 1,
-      "description": "Number of replicas for the deployment."
+      "description": "Number of replicas for the deployment. Set to 0 to scale to zero pods."
     },
     "envConfig": {
       "type": "object",

--- a/charts/llm-gateway/values.yaml
+++ b/charts/llm-gateway/values.yaml
@@ -1,4 +1,5 @@
 namespaceOverride: ""
+# Number of replicas for the deployment. Set to 0 to scale to zero pods.
 replicaCount: 1
 envConfig:
   PORT: 4000


### PR DESCRIPTION
## Summary
- Allow `replicaCount` to be set to 0 for scaling the deployment to zero pods
- Document `replicaCount` usage in `values.yaml`

## Testing
- `helm lint charts/llm-gateway`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6896212884848332b30af6f78bb67bc0