### PR TITLE
Add LiteLLM config map

### DIFF
--- a/charts/llm-gateway/templates/deployment.yaml
+++ b/charts/llm-gateway/templates/deployment.yaml
@@ -14,13 +14,16 @@ spec:
     metadata:
       labels:
         {{- include "llm-gateway.selectorLabels" . | nindent 8 }}
-      {{- if or .Values.envConfig .Values.envSecret }}
+      {{- if or (or .Values.envConfig .Values.envSecret) .Values.litellmConfig }}
       annotations:
         {{- if .Values.envConfig }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.envSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.litellmConfig }}
+        checksum/litellm-config: {{ include (print $.Template.BasePath "/litellm-configmap.yaml") . | sha256sum }}
         {{- end }}
       {{- end }}
     spec:
@@ -43,3 +46,15 @@ spec:
             - name: http
               containerPort: {{ .Values.envConfig.PORT }}
               protocol: TCP
+          {{- if .Values.litellmConfig }}
+          volumeMounts:
+            - name: litellm-config
+              mountPath: /litellm_config.yaml
+              subPath: litellm_config.yaml
+          {{- end }}
+      {{- if .Values.litellmConfig }}
+      volumes:
+        - name: litellm-config
+          configMap:
+            name: {{ include "llm-gateway.fullname" . }}-litellm-config
+      {{- end }}

--- a/charts/llm-gateway/templates/litellm-configmap.yaml
+++ b/charts/llm-gateway/templates/litellm-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.litellmConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "llm-gateway.fullname" . }}-litellm-config
+  namespace: {{ include "llm-gateway.namespace" . }}
+  labels:
+    {{- include "llm-gateway.labels" . | nindent 4 }}
+data:
+  litellm_config.yaml: |
+{{ toYaml .Values.litellmConfig | nindent 4 }}
+{{- end }}

--- a/charts/llm-gateway/values.schema.json
+++ b/charts/llm-gateway/values.schema.json
@@ -40,6 +40,12 @@
       },
       "description": "Sensitive environment variables added via Secret."
     },
+    "litellmConfig": {
+      "type": "object",
+      "default": {},
+      "additionalProperties": true,
+      "description": "Content of the litellm configuration file mounted at /litellm_config.yaml."
+    },
     "image": {
       "type": "object",
       "properties": {

--- a/charts/llm-gateway/values.yaml
+++ b/charts/llm-gateway/values.yaml
@@ -4,6 +4,8 @@ replicaCount: 1
 envConfig:
   PORT: 4000
 envSecret: {}
+# Content of litellm_config.yaml mounted into the container.
+litellmConfig: {}
 
 image:
   repository: albe83/llm-gw


### PR DESCRIPTION
## Summary
- allow customizing LiteLLM via `litellmConfig` value
- mount LiteLLM config file and reload on changes
## Testing
- `helm lint charts/llm-gateway`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68962608185c83329c8d2a287d4769e5