### PR TITLE
Add workflow to publish Helm chart to Docker Hub

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -1,0 +1,35 @@
+name: Publish Helm chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: albe83
+      DOCKER_REGISTRY: registry-1.docker.io
+      DOCKER_REPOSITORY: llm-gw-chart
+      CHART_DIR: charts/llm-gateway
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+      - name: Login to Docker Hub
+        env:
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+        run: echo "$DOCKER_TOKEN" | helm registry login -u "$DOCKER_USERNAME" --password-stdin "$DOCKER_REGISTRY"
+      - name: Lint chart
+        run: helm lint "$CHART_DIR"
+      - name: Package chart
+        run: helm package "$CHART_DIR"
+      - name: Push chart
+        run: |
+          CHART_VERSION=$(grep '^version:' "$CHART_DIR/Chart.yaml" | awk '{print $2}')
+          helm push "llm-gateway-${CHART_VERSION}.tgz" "oci://${DOCKER_REGISTRY}/${DOCKER_USERNAME}/${DOCKER_REPOSITORY}"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to package Helm chart and push to Docker Hub
- parameterize Docker registry, username, and repository
- split chart linting, packaging, and pushing into separate steps

## Testing
- `pytest`
- `helm lint charts/llm-gateway`


------
https://chatgpt.com/codex/tasks/task_b_68963706b5848332a9b265c94daaa8a7