### PR TITLE
Rename chart to llm-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-# llm-gw-chart
+# llm-gateway
+

--- a/charts/llm-gateway/Chart.yaml
+++ b/charts/llm-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: llm-gw-chart
+name: llm-gateway
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/llm-gateway/values.schema.json
+++ b/charts/llm-gateway/values.schema.json
@@ -51,7 +51,7 @@
       "properties": {
         "repository": {
           "type": "string",
-          "default": "albe83/llm-gw",
+          "default": "albe83/llm-gateway",
           "description": "Container image repository."
         },
         "tag": {

--- a/charts/llm-gateway/values.yaml
+++ b/charts/llm-gateway/values.yaml
@@ -8,7 +8,7 @@ envSecret: {}
 litellmConfig: {}
 
 image:
-  repository: albe83/llm-gw
+  repository: albe83/llm-gateway
   tag: v0.0.6
   digest: sha256:517933f26f912ccfdb1dcd5d7279816f92340085a98cbbbfe8f8a099f83ac43
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- rename helm chart to `llm-gateway`
- update chart metadata and defaults to match new name

## Testing
- `pytest`
- `helm lint charts/llm-gateway`


------
https://chatgpt.com/codex/tasks/task_b_689642797aa8833292a40aa5eacfd375